### PR TITLE
minor heading rephrasing

### DIFF
--- a/content/md/articles/content.md
+++ b/content/md/articles/content.md
@@ -35,7 +35,7 @@ basics.
 
 The ProtoREPL package for Clojure development in Atom.
 
-### [Cursive for Clojure Development](https://cursive-ide.com/userguide/)
+### [IntelliJ / Cursive for Clojure Development](https://cursive-ide.com/userguide/)
 
 The user guide for Cursive, the Clojure plugin for IntelliJ.
 


### PR DESCRIPTION
I propose we change the heading to be consistent with the other headings:

As an IntelliJ user, I was looking for the "IntelliJ" header.  

All the other headings start with the name of the IDE (e.g., Atom, Emacs, Vim, etc.).  The IntelliJ section is the only one that puts the name of the plugin rather than the name of the IDE.