### PR TITLE
Revert "Fix link to core_typed Quick Guide"

### DIFF
--- a/articles/ecosystem/core_typed/start/introduction_and_motivation/index.html
+++ b/articles/ecosystem/core_typed/start/introduction_and_motivation/index.html
@@ -89,7 +89,7 @@ subset of Clojure optimised for user error prevention, or attempt to check all C
 while making some compromises (it does the latter).</p><p>This might seem discouraging, but in practice core.typed will catch all type errors in your code.
 The problem is some Clojure idioms are so flexible it is often impossible to distinguish
 between intended and unintended usage.</p><p>A small example: <code>map</code> accepts either <code>nil</code> or a <code>Seqable</code> as a second argument. It is perfectly
-valid to provide an argument that is always <code>nil</code>, but it's probably not what the user intended.</p><p>So for best results, couple core.typed with all the usual testing/verification techniques.</p><h2 id="before-we-begin">Before we begin</h2><p>There are some details to keep in mind when using core.typed before you jump in to use it.</p><p>Read the <a href="../../quick_guide">Quick Guide</a>, and keep a copy handy when you follow along the rest of the tutorial.</p>
+valid to provide an argument that is always <code>nil</code>, but it's probably not what the user intended.</p><p>So for best results, couple core.typed with all the usual testing/verification techniques.</p><h2 id="before-we-begin">Before we begin</h2><p>There are some details to keep in mind when using core.typed before you jump in to use it.</p><p>Read the <a href="../quick_guide">Quick Guide</a>, and keep a copy handy when you follow along the rest of the tutorial.</p>
 
     <div id="prev-next">
         


### PR DESCRIPTION
Reverts clojure-doc/clojure-doc.github.io#9