### PR TITLE
change string example from doseq to let

### DIFF
--- a/content/md/articles/cookbooks/strings.md
+++ b/content/md/articles/cookbooks/strings.md
@@ -288,8 +288,8 @@ nested functions*, and get the resulting string at the end.
 (let [shrimp-varieties ["shrimp-kabobs" "shrimp creole" "shrimp gumbo"]]
   (with-out-str
     (print "We have ")
-    (doseq [name (str/join ", " shrimp-varieties)]
-      (print name))
+    (let [names (str/join ", " shrimp-varieties)]
+      (print names))
     (print "...")))
 ;=> "We have shrimp-kabobs, shrimp creole, shrimp gumbo..."
 ```


### PR DESCRIPTION
The existing example uses a string as a sequence, and thus prints one character at a time. This change swaps out `doseq` for `let` and updates the binding name to make the example a little bit more practical, while maintaining the spirit of the example (nested calls being captured by `with-out-str`).
