### PR TITLE
tutorials/editors.md: avoid "Q" for question

### DIFF
--- a/content/md/articles/tutorials/editors.md
+++ b/content/md/articles/tutorials/editors.md
@@ -3,7 +3,7 @@
  :layout :page}
 
 The last
-["State of the Union" Clojure survey](https://clojure.org/news/2023/06/30/state-of-clojure-2023) (Q20) indicated
+["State of the Union" Clojure survey](https://clojure.org/news/2023/06/30/state-of-clojure-2023) (survey question 20) indicated
 that Emacs is still the most popular editing environment, followed by IntelliJ/Cursive, VS Code, and Vim.
 
 If you are already using one of these editors, follow one of the guides for that


### PR DESCRIPTION
Hi!

When I read https://clojure-doc.org/articles/tutorials/editors/, I didn't understand what "Q20" was.

In this PR, I propose changing "Q20" to "survey question 20".