### PR TITLE
add `sort` and `sort-by` to the collections operations section

### DIFF
--- a/content/md/articles/language/collections_and_sequences.md
+++ b/content/md/articles/language/collections_and_sequences.md
@@ -790,7 +790,7 @@ Do not confuse `empty?` with `empty`. This can be a source of great confusion:
 
 ### contains?
 
-`contains` returns true if the provided *key* is present in a collection. `contains` is similar to `get` in that vectors treat the key as an index. `contains` will always return false for lists.
+`contains?` returns true if the provided *key* is present in a collection. `contains?` is similar to `get` in that vectors treat the key as an index. `contains?` does not work for lists.
 
 ```klipse-clojure
 (contains? {:a 1 :b 2 :c 3} :c)

--- a/deps.edn
+++ b/deps.edn
@@ -3,7 +3,7 @@
         ring/ring-devel {:mvn/version "1.12.1"}
         compojure/compojure {:mvn/version "1.6.2"}
         cryogen-flexmark/cryogen-flexmark {:mvn/version "0.1.5"}
-        cryogen-core/cryogen-core {:mvn/version "0.4.4"}}
+        cryogen-core/cryogen-core {:mvn/version "0.4.6"}}
  :aliases {;; Run with `clojure -M:build`
            :build {:main-opts ["-m" "cryogen.core"]}
            ;; Start a server serving the blog: `clojure -X:serve`


### PR DESCRIPTION
The primary add here is adding sort and sort-by. A question came up in the beginners channel in slack a few days back (specifically using sort in a way that only makes sense for sort-by), so I thought covering them together might be helpful.

Two supplemental changes:
- the description of `contains?` uses `contains` in a way that might cause confusion as to the function name (with or without the question mark), so change all the function name references to include the question mark, and make some language a bit more generic to cover the behavior of both clj and cljs.
- bump cryogen-core to 0.4.6 - there was apparently a bug in 0.4.4 where if there were no 'posts' (or no 'posts' folder), the build would fail. I experienced this locally and then found that https://github.com/cryogen-project/cryogen-core/pull/168 had fixed it about a week ago. 
I typically wouldn't bump deps on a project in which I'm not heavily involved. In this case, I built the site with both 0.4.3 and 0.4.6 and diffed the 'public' folders from each - they were identical (modulo timestamps), so I felt ok bumping the dep because I could have high confidence that the build outputs are not negatively impacted by the bump.