### PR TITLE
Correct filter example

### DIFF
--- a/content/md/articles/language/collections_and_sequences.md
+++ b/content/md/articles/language/collections_and_sequences.md
@@ -954,7 +954,7 @@ single value.
 ```
 
 ```klipse-clojure
-(filter #(if (< (count %) 5) %) ["Paul" "Celery" "Computer" "Rudd" "Tayne"])
+(filter #(< (count %) 5) ["Paul" "Celery" "Computer" "Rudd" "Tayne"])
 ;; ⇒ ("Paul" "Rudd")
 ```
 


### PR DESCRIPTION
To better show what filter does, without the need to "carry over" the original value.